### PR TITLE
Fix link to title capitalization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Ensure your pull request adheres to the following guidelines:
 
 - Search previous suggestions before making a new one, as yours may be a duplicate.
 - Make an individual pull request for each suggestion.
-- Use [title-casing](http://titlecapitalization.com) (AP style).
+- Use [title-casing](http://titlecapitalize.com) (AP style).
 - Use the following format: `[Title Case Name](link) - Description.`
 - Keep descriptions short and simple, but descriptive.
 - Start the description with a capital and end with a full stop/period.


### PR DESCRIPTION
The referred link seems to not exist anymore.

I wasn't sure how to check for the original choice.
https://titlecaseconverter.com/ looked like a good option, but https://titlecapitalize.com/ seemed closer to the original webpage link, so went with that option.

Or I can change to something else, if the domain has just been replaced for something else entirely :P