### PR TITLE
Add Triagewall - local-LLM Suricata alert triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - [Terraform Module for Suricata](https://github.com/onetwopunch/terraform-google-suricata) - Terraform module to setup Google Cloud packet mirroring and send packets to Suricata.
 - [InfluxDB Suricata Input Plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/suricata) - Input Plugin for Telegraf to collect and forward Suricata `stats` logs (included out of the box in recent Telegraf releases).
 - [suricata_exporter](https://github.com/corelight/suricata_exporter) - Simple Prometheus exporter written in Go exporting stats metrics scraped from Suricata socket.
+- [Triagewall](https://github.com/aaronphifer/triagewall) - Local-LLM triage layer for Suricata alerts, using a tunable prefilter and Ollama classifier to reduce alert volume.
 
 
 ## Programming Libraries and Toolkits


### PR DESCRIPTION
Adds Triagewall, a local-LLM triage layer for Suricata. AGPL-3.0 licensed, Docker Compose deployment, includes a demo mode for evaluation.